### PR TITLE
Fix accuracy label in final project notebook

### DIFF
--- a/final project.ipynb
+++ b/final project.ipynb
@@ -1151,7 +1151,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accurecy =  0.13956927845798794\n"
+      "Accuracy =  0.13956927845798794\n"
      ]
     }
    ],
@@ -1179,7 +1179,7 @@
     "\n",
     "Acc=Linear.score(X_test, y_test)\n",
     "\n",
-    "print('Accurecy = ' , Acc)"
+    "print('Accuracy = ' , Acc)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Correct typo in performance print statement from 'Accurecy' to 'Accuracy'
- Update notebook output to reflect corrected label

## Testing
- `python - <<'PY'
Acc=0.13956927845798794
print('Accuracy = ', Acc)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac9f2a84d88323b284fbae2ea8310c